### PR TITLE
extra information in session.updated callback

### DIFF
--- a/src/session.luau
+++ b/src/session.luau
@@ -25,6 +25,7 @@ type TransactionId = types.TransactionId
 type TransactionInfo = types.TransactionInfo
 type TransactionAction = types.TransactionAction
 type TransactionData = types.TransactionData
+type UpdateTypes = types.UpdateType
 
 local function migrate<T>(session: Session<T>, stored: StoredData<T>)
     local migrations = session._options.migrations
@@ -60,12 +61,12 @@ local function create_migrations_table(session: Session<any>)
     return migrations
 end
 
-local function run_updated<T>(session: Session<T>)
+local function run_updated<T>(session: Session<T>, source: UpdateTypes)
     local data = session._cached.data
     local fn = session._updated
     local copy = util.deep_freeze(util.clone(data))
 
-    return fn(copy)
+    return fn(copy, source)
 end
 
 local function update<T>(
@@ -148,7 +149,7 @@ local function pull_auto<T>(session: Session<T>, transactions: { [TransactionId]
 
     session._cached = result
     LOG(`{session._name} calling updated -`, debug.info(session._updated, "sl"))
-    run_updated(session)
+    run_updated(session, "from_source")
 end
 
 local function force_pull<T>(session: Session<T>)
@@ -167,7 +168,7 @@ local function force_pull<T>(session: Session<T>)
     session._next_save_opportunity = AUTOSAVE_DELAY
     session._cached = result
     LOG(`{session._name} calling updated on force`, debug.info(session._updated, "sl"))
-    run_updated(session)
+    run_updated(session, "from_source")
 end
 
 local function thread<T>(session: Session<T>)
@@ -226,11 +227,11 @@ local function patch_regular<T, U...>(session: Session<T>, fn: Action<T, U...>, 
 
         table.insert(session._changes, actions.create_record(fn, ...) )
         session._cached.data = a
-        run_updated(session)
+        run_updated(session, "from_cache")
     else
         table.insert(session._changes, actions.create_record(fn, ...) )
         session._cached.data = fn(session._cached.data, ...)
-        run_updated(session)
+        run_updated(session, "from_cache")
     end
 end
 
@@ -243,11 +244,11 @@ local function patch<T, U...>(session: Session<T>, fn: Action<T, U...>, ...: U..
     end
 end
 
-local function updated<T>(session: Session<T>, new: (data: T) -> ())
+local function updated<T>(session: Session<T>, new: (data: T, source: UpdateTypes) -> ())
     if coroutine.status(session._thread) == "dead" then error("thread is dead") end
     session._updated = new
     LOG(`{session._name} calling updated register`, debug.info(new, "sl"))
-    run_updated(session)
+    run_updated(session, "default_data")
 end
 
 local function stop<T>(session: Session<T>)

--- a/src/types.luau
+++ b/src/types.luau
@@ -42,7 +42,7 @@ export type Session<T> = {
     --- When the next refresh happens.
     _next_save_opportunity: number,
     --- Runs to reconcile the Datastores into the data.
-    _updated: (T) -> (),
+    _updated: (T, UpdateType) -> (),
     --- The currently stored data.
     _cached: StoredData<T>,
     --- The thread responsible for autosaving.

--- a/src/types.luau
+++ b/src/types.luau
@@ -57,7 +57,7 @@ export type Session<T> = {
     --- Binds a function to whenever the session receives updated data.
     --- This should be reconciled into your own game state. When called, it will
     --- run the function given immediately.
-    updated: (Session<T>, (T) -> ()) -> (),
+    updated: (Session<T>, (T, UpdateType) -> ()) -> (),
     --- Stops polling the datastore for data, and disables any patching. This
     --- performs one more save. Releases the lock if it was locked.
     stop: (Session<T>) -> (),
@@ -97,5 +97,7 @@ export type StoredData<T> = {
     migrations_performed: { string },
     data: T
 }
+
+export type UpdateType = "from_cache" | "default_data" | "from_source"
 
 return {}


### PR DESCRIPTION
Thank you for making this library! I was messing around with it earlier and noticed that session.updated runs for 3 seperate cases and thought giving the user a little more context on what caused the update might be helpful.

This might be helpful for:
- Performing checks on data that is pulled via UpdateAsync
- Replicating a player’s initial data exclusively during the first UpdateAsync

Another possible option would have been to poll until the first pull from UpdateAsync happened, but I don't know how you envisioned the library to work in that regard so I'm going with this alternative.