### PR TITLE
Prevent duplicate migrations

### DIFF
--- a/src/session.luau
+++ b/src/session.luau
@@ -39,7 +39,7 @@ local function migrate<T>(session: Session<T>, stored: StoredData<T>)
     if #migrations == #stored.migrations_performed then return false end
     LOG(`{session.name}: Performing Migration`)
     for i, migration in migrations do
-        if table.find(stored.migrations_performed, migration) then continue end
+        if table.find(stored.migrations_performed, migration.step) then continue end
         LOG(`{session.name}: Migration Step {migration.step}`)
 
         local result = migration.migrate(stored.data)


### PR DESCRIPTION
This pull request prevents duplicate migrations, which basically force reset any data added through migrations.