### PR TITLE
Fix non-strict mode missing run_updated in commit_transaction_early

### DIFF
--- a/src/session.luau
+++ b/src/session.luau
@@ -463,6 +463,7 @@ local function commit_transaction_early<T, U...>(session: Session<T>, fn: Action
         end
 
         session._.cached.data = result
+        run_updated(session)
     end
 end
 


### PR DESCRIPTION
Successful transactions in strict mode call run_updated in commit_transaction_early, but this was missing from non-strict mode. This fix ensures both modes use the same timing for updates.